### PR TITLE
Don't hardcode GhostScript binary path.

### DIFF
--- a/treepoem/__init__.py
+++ b/treepoem/__init__.py
@@ -54,7 +54,7 @@ EPS_TEMPLATE = """\
 
 """ + BASE_PS
 
-BBOX_COMMAND = ['/usr/bin/gs', '-sDEVICE=bbox', '-dBATCH', '-dSAFER', '-']
+BBOX_COMMAND = ['gs', '-sDEVICE=bbox', '-dBATCH', '-dSAFER', '-']
 
 
 class PostscriptError(RuntimeError):


### PR DESCRIPTION
This way it's getting searched for in `$PATH`.
