### PR TITLE
Support binary barcode data

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,11 @@ History
 
 .. Insert new release notes below this line
 
+Development
+-----------
+
+* Support binary barcode data.
+
 1.4.1 (2018-05-01)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -51,8 +51,8 @@ Generates a barcode and returns it as a PIL image file object (specifically, a
 
 ``barcode_type`` is the name of the barcode type to generate (see below).
 
-``data`` is the string of data to embed in the barcode - the amount that can be
-embedded varies by type.
+``data`` is a string or a byte sequence (``bytes``) of data to embed in the
+barcode - the amount that can be embedded varies by type.
 
 ``options`` is a dictionary of strings-to-strings of extra options to be passed
 to BWIPP_, as per its docs.

--- a/tests/test_treepoem.py
+++ b/tests/test_treepoem.py
@@ -13,6 +13,7 @@ import treepoem
 @pytest.mark.parametrize('barcode_type,barcode_data', [
     ('qrcode', "This is qrcode barcode."),
     ('azteccode', "This is azteccode barcode."),
+    ('azteccode', b"This is azteccode barcode."),
     ('pdf417', "This is pdf417 barcode."),
     ('interleaved2of5', "0123456789"),
     ('code128', "This is code128 barcode."),

--- a/treepoem/__init__.py
+++ b/treepoem/__init__.py
@@ -114,7 +114,7 @@ def _get_ghostscript_binary():
 def _encode(data):
     if isinstance(data, str):
         data = data.encode('utf8')
-    return codecs.encode(data.encode('utf8'), 'hex_codec').decode('ascii')
+    return codecs.encode(data, 'hex_codec').decode('ascii')
 
 
 def _format_options(options):

--- a/treepoem/__init__.py
+++ b/treepoem/__init__.py
@@ -112,6 +112,8 @@ def _get_ghostscript_binary():
 
 
 def _encode(data):
+    if isinstance(data, str):
+        data = data.encode('utf8')
     return codecs.encode(data.encode('utf8'), 'hex_codec').decode('ascii')
 
 


### PR DESCRIPTION
Only encode data if it is a string.

~~I added a test, but all tests in `test_treepoem.py` fail for me, so I am assuming this is not a problem with this particular change.~~ All tests succeed on Travis.

Fixes #112