### PR TITLE
Remove Python 2 support

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,7 @@ History
   performance improvements. You can read its changelog in the vendored copy in
   the `treepoem repo
   <https://github.com/adamchainz/treepoem/blob/master/treepoem/postscriptbarcode/CHANGES>`__.
+* Drop Python 2 support, only Python 3.4+ is supported now.
 
 2.0.0 (2018-08-04)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -10,8 +10,7 @@ Treepoem
 
 
 A cleverly named, but very simple python barcode renderer wrapping the
-BWIPP_ library and ``ghostscript`` command line tool, Python 2.7 and 3.3+
-compatible.
+BWIPP_ library and ``ghostscript`` command line tool.
 
 ------------
 Installation
@@ -22,6 +21,8 @@ Install from **pip**:
 .. code-block:: sh
 
     pip install treepoem
+
+Python 3.4+ supported.
 
 You'll also need Ghostscript installed. On Ubuntu/Debian this can be installed
 with:

--- a/make_data.py
+++ b/make_data.py
@@ -1,7 +1,4 @@
 #!/usr/bin/env python
-# -*- encoding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import os
 
 BASE_DIR = os.path.dirname(__file__)
@@ -37,9 +34,6 @@ def load_barcode_types():
 
 def write_out_barcode_types(all_barcode_types):
     with open(BARCODE_TYPES_PATH, 'w') as fp:
-        fp.write('# -*- encoding:utf-8 -*-\n')
-        fp.write('from __future__ import absolute_import, division, print_function, unicode_literals\n')
-        fp.write('\n\n')
         fp.write('class BarcodeType(object):\n')
         fp.write('    def __init__(self, type_code, description):\n')
         fp.write('        self.type_code = type_code\n')

--- a/requirements.in
+++ b/requirements.in
@@ -1,10 +1,8 @@
 docutils
 flake8
 flake8-commas
-futures<3.2.0
 isort
 multilint
 Pillow
 Pygments
 pytest
-six

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,28 +6,19 @@
 #
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
-backports.functools-lru-cache==1.5 ; python_version < '3.0'   # via isort
-configparser==3.7.4       # via entrypoints, flake8
 docutils==0.14
 entrypoints==0.3          # via flake8
-enum34==1.1.6             # via flake8
 flake8-commas==2.0.0
 flake8==3.7.7
-funcsigs==1.0.2           # via pytest
-functools32==3.2.3.post2 ; python_version < '3.0'  # via flake8
-futures==3.1.1
-isort==4.3.17
+isort==4.3.18
 mccabe==0.6.1             # via flake8
-more-itertools==5.0.0     # via pytest
+more-itertools==7.0.0     # via pytest
 multilint==2.4.0
-pathlib2==2.3.3           # via pytest
 pillow==6.0.0
-pluggy==0.9.0             # via pytest
+pluggy==0.11.0            # via pytest
 py==1.8.0                 # via pytest
 pycodestyle==2.5.0        # via flake8
 pyflakes==2.1.1           # via flake8
-pygments==2.3.1
+pygments==2.4.0
 pytest==4.4.1
-scandir==1.10.0           # via pathlib2
-six==1.12.0
-typing==3.6.6             # via flake8
+six==1.12.0               # via multilint, pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,15 +1,7 @@
-[bdist_wheel]
-universal = 1
-
 [flake8]
 max-line-length = 130
 
 [isort]
-add_imports =
-    from __future__ import absolute_import
-    from __future__ import division
-    from __future__ import print_function
-    from __future__ import unicode_literals
 line_length = 120
 known_first_party = treepoem
 multi_line_output = 5

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-import codecs
 import os
 import re
 
@@ -9,17 +5,17 @@ from setuptools import find_packages, setup
 
 
 def get_version(filename):
-    with codecs.open(filename, 'r', 'utf-8') as fp:
+    with open(filename, 'r') as fp:
         contents = fp.read()
     return re.search(r"__version__ = ['\"]([^'\"]+)['\"]", contents).group(1)
 
 
 version = get_version(os.path.join('treepoem', '__init__.py'))
 
-with codecs.open('README.rst', 'r', 'utf-8') as readme_file:
+with open('README.rst', 'r') as readme_file:
     readme = readme_file.read()
 
-with codecs.open('HISTORY.rst', 'r', 'utf-8') as history_file:
+with open('HISTORY.rst', 'r') as history_file:
     history = history_file.read().replace('.. :changelog:', '')
 
 setup(
@@ -41,9 +37,8 @@ setup(
     include_package_data=True,
     install_requires=[
         'Pillow',
-        'six',
     ],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=3.4',
     license="MIT",
     zip_safe=False,
     keywords='barcode bwipp postscript ghostscript qr qrcode aztec azteccode pdf417 interleaved2of5 i25 code128 code39',
@@ -52,8 +47,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
-        "Programming Language :: Python :: 2",
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,3 @@
-# -*- coding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import re
 import subprocess
 import sys

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,3 @@
-# -*- coding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import sys
 
 import pytest

--- a/tests/test_treepoem.py
+++ b/tests/test_treepoem.py
@@ -1,11 +1,7 @@
-# -*- coding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import sys
 from os import path
 
 import pytest
-import six
 from PIL import EpsImagePlugin, Image, ImageChops
 
 import treepoem
@@ -83,6 +79,6 @@ def test_unsupported_barcode_type():
 
 def test_barcode_types():
     for code, barcode_type in treepoem.barcode_types.items():
-        assert isinstance(code, six.text_type)
+        assert isinstance(code, str)
         assert barcode_type.type_code == code
-        assert isinstance(barcode_type.description, six.text_type)
+        assert isinstance(barcode_type.description, str)

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,13 @@
 [tox]
-envlist = py{27,3}-codestyle, py{27,3}
+envlist =
+    py3,
+    py3-codestyle
 
 [testenv]
 install_command = pip install --no-deps {opts} {packages}
 deps =
     -rrequirements.txt
 commands = pytest {posargs}
-
-[testenv:py27-codestyle]
-changedir = {toxinidir}
-# setup.py check broken on travis python 2.7
-skip_install = true
-commands = multilint --skip setup.py
 
 [testenv:py3-codestyle]
 changedir = {toxinidir}

--- a/treepoem/__init__.py
+++ b/treepoem/__init__.py
@@ -1,13 +1,9 @@
-# -*- encoding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import codecs
 import io
 import os
 import subprocess
 import sys
 
-import six
 from PIL import EpsImagePlugin
 
 from .data import BarcodeType, barcode_types
@@ -113,7 +109,7 @@ def _get_ghostscript_binary():
 
 
 def _encode(data):
-    if isinstance(data, six.text_type):
+    if isinstance(data, str):
         data = data.encode('utf-8')
     return codecs.encode(data, 'hex_codec').decode('ascii')
 

--- a/treepoem/__main__.py
+++ b/treepoem/__main__.py
@@ -1,6 +1,3 @@
-# -*- encoding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import argparse
 import sys
 from textwrap import fill

--- a/treepoem/data.py
+++ b/treepoem/data.py
@@ -1,7 +1,3 @@
-# -*- encoding:utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
-
 class BarcodeType(object):
     def __init__(self, type_code, description):
         self.type_code = type_code


### PR DESCRIPTION
Fixes #148.

* Remove coding header and `__future__` imports
* Remove use of `six`
* In `setup.py`, remove use of `codecs.open`, stop requiring 'six' in `install_requires`, update `python_requires`, remove `extras_require` Python 2 only requirements, and update `classifiers`
* In `README.rst`, update to "Python 3.4+ supported."
* In `requirements.in`,  remove `futures` pin, and `six`, and recompile
* In `tox.ini`, stop testing on Python 2
* In `setup.cfg`, remove isort's `add_imports` for `__future__` imports, and remove universal wheel building