### PR TITLE
Switch 'pip install' for 'python -m pip install'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,6 @@ install:
 - wget https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs950/ghostscript-9.50-linux-x86_64.tgz
 - tar xvf ghostscript-9.50-linux-x86_64.tgz
 - sudo mv ghostscript-9.50-linux-x86_64/gs-950-linux-x86_64 /usr/bin/gs
-- pip install tox-travis
+- python -m pip install tox-travis
 
 script: tox

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Install from **pip**:
 
 .. code-block:: sh
 
-    pip install treepoem
+    python -m pip install treepoem
 
 Python 3.5 to 3.8 supported.
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     py38-codestyle
 
 [testenv]
-install_command = pip install --no-deps {opts} {packages}
+install_command = python -m pip install --no-deps {opts} {packages}
 commands = pytest {posargs}
 
 [testenv:py35]


### PR DESCRIPTION
As per [Brett Cannon's article](https://snarky.ca/why-you-should-use-python-m-pip/).