### PR TITLE
Remove tox-gh-actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,8 @@ jobs:
         tar xvf ghostscript-9.52-linux-x86_64.tgz
         mv ghostscript-9.52-linux-x86_64/gs-952-linux-x86_64 ./gs
     - name: Install dependencies
-      run: python -m pip install --upgrade tox tox-gh-actions
+      run: python -m pip install --upgrade tox
     - name: Run tox targets for ${{ matrix.python-version }}
-      run: python -m tox
+      run: |
+        ENV_PREFIX=$(tr -C -d "0-9" <<< "${{ matrix.python-version }}")
+        TOXENV=$(tox --listenvs | grep "^py$ENV_PREFIX" | tr '\n' ',') python -m tox

--- a/tox.ini
+++ b/tox.ini
@@ -4,14 +4,6 @@ envlist =
     py{35,36,37,38,39}
     py38-codestyle
 
-[gh-actions]
-python =
-    3.5: py35
-    3.6: py36
-    3.7: py37
-    3.8: py38, py38-codestyle
-    3.9: py39
-
 [testenv]
 commands = python -W error::DeprecationWarning -W error::PendingDeprecationWarning -m pytest {posargs}
 


### PR DESCRIPTION
Use a couple of lines of shell instead. This removes the need to maintain the `[gh-actions]` section of tox.ini.
