### PR TITLE
Improve Flake8 config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,5 @@ console_scripts =
     treepoem=treepoem.__main__:main
 
 [flake8]
-max-line-length = 80
-select = E,F,W,B,B950,C,I,TYP
-ignore = E203,E501,W503
+max-line-length = 88
+extend-ignore = E203

--- a/src/treepoem/__init__.py
+++ b/src/treepoem/__init__.py
@@ -30,7 +30,7 @@ showpage
 """
 
 # Error handling from:
-# https://github.com/bwipp/postscriptbarcode/wiki/Developing-a-Frontend-to-BWIPP#use-bwipps-error-reporting  # noqa: B950
+# https://github.com/bwipp/postscriptbarcode/wiki/Developing-a-Frontend-to-BWIPP#use-bwipps-error-reporting  # noqa: E501
 BBOX_TEMPLATE = (
     """\
 %!PS


### PR DESCRIPTION
Use only Black compat options. Removing 'select' declaration means that plugin error codes are selected by default.
