### PR TITLE
added template options for size / scalability

### DIFF
--- a/src/treepoem/__init__.py
+++ b/src/treepoem/__init__.py
@@ -149,7 +149,7 @@ def generate_barcode(
     barcode_type: str,
     data: str | bytes,
     options: dict[str, str | bool] | None = None,
-    template_options: dict[str, str ] | None = None
+    template_options: dict[str, str] | None = None,
 ) -> EpsImagePlugin.EpsImageFile:
     if barcode_type not in barcode_types:
         raise NotImplementedError(f"unsupported barcode type {barcode_type!r}")
@@ -157,8 +157,10 @@ def generate_barcode(
         options = {}
     if template_options is None:
         template_options = {"scale_x": "2", "scale_y": "2"}
-    
+
     code = _format_code(barcode_type, data, options)
     bbox_lines = _get_bbox(code, template_options)
-    full_code = EPS_TEMPLATE.format(bbox=bbox_lines, bwipp=BWIPP, code=code, **template_options)
+    full_code = EPS_TEMPLATE.format(
+        bbox=bbox_lines, bwipp=BWIPP, code=code, **template_options
+    )
     return EpsImagePlugin.EpsImageFile(io.BytesIO(full_code.encode()))

--- a/tests/test_treepoem.py
+++ b/tests/test_treepoem.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
+import math
 import sys
 from os import path
 
 import pytest
 from PIL import EpsImagePlugin, Image, ImageChops
 
-import math
-
 # import treepoem
 from src import treepoem
+
 
 @pytest.mark.parametrize(
     "barcode_type,barcode_data",
@@ -26,12 +26,11 @@ from src import treepoem
 def test_barcode(barcode_type, barcode_data):
     actual = treepoem.generate_barcode(barcode_type, barcode_data)
     actual_resized = treepoem.generate_barcode(
-        barcode_type, 
-        barcode_data, 
-        template_options={"scale_x": "4", "scale_y": "4"}
+        barcode_type, barcode_data, template_options={"scale_x": "4", "scale_y": "4"}
     )
-    assert  math.ceil(actual.size[0]/2) == math.ceil(actual_resized.size[0]/4) \
-        and math.ceil(actual.size[1]/2) == math.ceil(actual_resized.size[1]/4)
+    assert math.ceil(actual.size[0] / 2) == math.ceil(
+        actual_resized.size[0] / 4
+    ) and math.ceil(actual.size[1] / 2) == math.ceil(actual_resized.size[1] / 4)
 
     fixture_path = "{dirname}/fixtures/{barcode_type}.png".format(
         dirname=path.dirname(__file__), barcode_type=barcode_type
@@ -50,6 +49,7 @@ def test_barcode(barcode_type, barcode_data):
     actual.close()
 
     print(expected.size)
+
 
 @pytest.fixture
 def pretend_windows():

--- a/tests/test_treepoem.py
+++ b/tests/test_treepoem.py
@@ -7,8 +7,7 @@ from os import path
 import pytest
 from PIL import EpsImagePlugin, Image, ImageChops
 
-# import treepoem
-from src import treepoem
+import treepoem
 
 
 @pytest.mark.parametrize(

--- a/tests/test_treepoem.py
+++ b/tests/test_treepoem.py
@@ -6,8 +6,10 @@ from os import path
 import pytest
 from PIL import EpsImagePlugin, Image, ImageChops
 
-import treepoem
+import math
 
+# import treepoem
+from src import treepoem
 
 @pytest.mark.parametrize(
     "barcode_type,barcode_data",
@@ -23,6 +25,13 @@ import treepoem
 )
 def test_barcode(barcode_type, barcode_data):
     actual = treepoem.generate_barcode(barcode_type, barcode_data)
+    actual_resized = treepoem.generate_barcode(
+        barcode_type, 
+        barcode_data, 
+        template_options={"scale_x": "4", "scale_y": "4"}
+    )
+    assert  math.ceil(actual.size[0]/2) == math.ceil(actual_resized.size[0]/4) \
+        and math.ceil(actual.size[1]/2) == math.ceil(actual_resized.size[1]/4)
 
     fixture_path = "{dirname}/fixtures/{barcode_type}.png".format(
         dirname=path.dirname(__file__), barcode_type=barcode_type
@@ -38,9 +47,9 @@ def test_barcode(barcode_type, barcode_data):
         expected = Image.open(fixture)
         bbox = ImageChops.difference(actual, expected).getbbox()
         assert bbox is None
-
     actual.close()
 
+    print(expected.size)
 
 @pytest.fixture
 def pretend_windows():


### PR DESCRIPTION
Hi @adamchainz,

I added some template options in line with this documentation: [Resizing-Symbols](https://github.com/bwipp/postscriptbarcode/wiki/Resizing-Symbols) and adjusted the PyTest `test_barcode` to cover resizing a barcode. 

I would appreciate if you would consider to incorporate this feature. Happy to receive feedback regarding the implementation.



