### PR TITLE
Move from isort to reorder-python-imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,10 +28,16 @@ repos:
   - id: blacken-docs
     additional_dependencies:
     - black==22.10.0
-- repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+- repo: https://github.com/asottile/reorder_python_imports
+  rev: v3.9.0
   hooks:
-  - id: isort
+  - id: reorder-python-imports
+    args:
+    - --py37-plus
+    - --application-directories
+    - .:example:src
+    - --add-import
+    - 'from __future__ import annotations'
 - repo: https://github.com/PyCQA/flake8
   rev: 5.0.4
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,6 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 target-version = ['py37']
 
-[tool.isort]
-profile = "black"
-add_imports = "from __future__ import annotations"
-
 [tool.mypy]
 mypy_path = "src/"
 show_error_codes = true

--- a/src/treepoem/__init__.py
+++ b/src/treepoem/__init__.py
@@ -8,7 +8,8 @@ import sys
 
 from PIL import EpsImagePlugin
 
-from .data import BarcodeType, barcode_types
+from .data import barcode_types
+from .data import BarcodeType
 
 __all__ = ["generate_barcode", "TreepoemError", "BarcodeType", "barcode_types"]
 

--- a/src/treepoem/__main__.py
+++ b/src/treepoem/__main__.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import argparse
 import sys
 from textwrap import fill
-from typing import BinaryIO, Tuple, cast
+from typing import BinaryIO
+from typing import cast
+from typing import Tuple
 
 from . import generate_barcode
 from .data import barcode_types

--- a/tests/test_treepoem.py
+++ b/tests/test_treepoem.py
@@ -4,7 +4,9 @@ import sys
 from os import path
 
 import pytest
-from PIL import EpsImagePlugin, Image, ImageChops
+from PIL import EpsImagePlugin
+from PIL import Image
+from PIL import ImageChops
 
 import treepoem
 


### PR DESCRIPTION
It’s [way faster](https://twitter.com/codewithanthony/status/1553034384206438401) and its one-import-per-line style prevents merge conflicts.
