### PR TITLE
Feature/size option added option for size / scalability

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,8 @@
 Changelog
 =========
 
-* Added an option ``scale`` to treepoem, that allows to increase or decrease the dimensions of the generated EpsImageFile proportionally.
+* Added ``scale`` parameter to ``generate_barcode()`` and ``-s``/``--scale`` option to the command line.
+  Changing the scale changes the pixels in the output image.
 
 3.21.0 (2023-07-24)
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* Added an option ``scale`` to treepoem, that allows to increase or decrease the dimensions of the generated EpsImageFile proportionally.
+
 3.21.0 (2023-07-24)
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ Improve your skills with `one of my books <https://adamj.eu/books/>`__.
 API
 ===
 
-``generate_barcode(barcode_type: str, data: str | bytes, options: dict[str, str | bool] | None=None) -> EpsImageFile``
+``generate_barcode(barcode_type: str, data: str | bytes, options: dict[str, str | bool] | None=None, scale: int = 2) -> EpsImageFile``
 ----------------------------------------------------------------------------------------------------------------------
 
 Generates a barcode and returns it as a PIL image file object (specifically, a

--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ API
 ===
 
 ``generate_barcode(barcode_type: str, data: str | bytes, options: dict[str, str | bool] | None=None, scale: int = 2) -> EpsImageFile``
-----------------------------------------------------------------------------------------------------------------------
+--------------------------------------------------------------------------------------------------------------------------------------
 
 Generates a barcode and returns it as a PIL image file object (specifically, a
 ``PIL.EpsImagePlugin.EpsImageFile``).
@@ -81,6 +81,9 @@ that can be embedded varies by type.
 
 ``options`` is a dictionary of strings-to-strings of extra options to be passed
 to BWIPP_, as per its docs.
+
+``scale`` controls the output image size.
+Use ``1`` for the smallest image and larger values for larger images.
 
 For example, this generates a QR code image, and saves it to a file using
 standard PIL ``Image.save()``:

--- a/README.rst
+++ b/README.rst
@@ -68,8 +68,8 @@ Improve your skills with `one of my books <https://adamj.eu/books/>`__.
 API
 ===
 
-``generate_barcode(barcode_type: str, data: str | bytes, options: dict[str, str | bool] | None=None, scale: int = 2) -> EpsImageFile``
---------------------------------------------------------------------------------------------------------------------------------------
+``generate_barcode(barcode_type: str, data: str | bytes, options: dict[str, str | bool] | None=None, *, scale: int = 2) -> EpsImageFile``
+-----------------------------------------------------------------------------------------------------------------------------------------
 
 Generates a barcode and returns it as a PIL image file object (specifically, a
 ``PIL.EpsImagePlugin.EpsImageFile``).

--- a/src/treepoem/__init__.py
+++ b/src/treepoem/__init__.py
@@ -150,7 +150,7 @@ def generate_barcode(
     barcode_type: str,
     data: str | bytes,
     options: dict[str, str | bool] | None = None,
-    scale: int | None = 2,
+    scale: int = 2,
 ) -> EpsImagePlugin.EpsImageFile:
     if barcode_type not in barcode_types:
         raise NotImplementedError(f"unsupported barcode type {barcode_type!r}")

--- a/src/treepoem/__init__.py
+++ b/src/treepoem/__init__.py
@@ -156,7 +156,8 @@ def generate_barcode(
         raise NotImplementedError(f"unsupported barcode type {barcode_type!r}")
     if options is None:
         options = {}
-    scale = scale or 2
+    if scale < 1:
+        raise ValueError("scale must be at least 1")
 
     code = _format_code(barcode_type, data, options)
     bbox_lines = _get_bbox(code, scale)

--- a/src/treepoem/__init__.py
+++ b/src/treepoem/__init__.py
@@ -21,7 +21,7 @@ BASE_PS = """\
 
 /Helvetica findfont 10 scalefont setfont
 gsave
-2 2 scale
+{scale} {scale} scale
 10 10 moveto
 
 {code}
@@ -82,8 +82,8 @@ def _read_file(file_path: str) -> str:
 BWIPP = _read_file(BWIPP_PATH)
 
 
-def _get_bbox(code: str) -> str:
-    full_code = BBOX_TEMPLATE.format(bwipp=BWIPP, code=code)
+def _get_bbox(code: str, scale: int) -> str:
+    full_code = BBOX_TEMPLATE.format(bwipp=BWIPP, code=code, scale=scale)
     ghostscript = _get_ghostscript_binary()
     gs_process = subprocess.Popen(
         [ghostscript, "-sDEVICE=bbox", "-dBATCH", "-dSAFER", "-"],
@@ -150,12 +150,17 @@ def generate_barcode(
     barcode_type: str,
     data: str | bytes,
     options: dict[str, str | bool] | None = None,
+    scale: int | None = 2,
 ) -> EpsImagePlugin.EpsImageFile:
     if barcode_type not in barcode_types:
         raise NotImplementedError(f"unsupported barcode type {barcode_type!r}")
     if options is None:
         options = {}
+    scale = scale or 2
+
     code = _format_code(barcode_type, data, options)
-    bbox_lines = _get_bbox(code)
-    full_code = EPS_TEMPLATE.format(bbox=bbox_lines, bwipp=BWIPP, code=code)
+    bbox_lines = _get_bbox(code, scale)
+    full_code = EPS_TEMPLATE.format(
+        bbox=bbox_lines, bwipp=BWIPP, code=code, scale=scale
+    )
     return EpsImagePlugin.EpsImageFile(io.BytesIO(full_code.encode()))

--- a/src/treepoem/__init__.py
+++ b/src/treepoem/__init__.py
@@ -150,6 +150,7 @@ def generate_barcode(
     barcode_type: str,
     data: str | bytes,
     options: dict[str, str | bool] | None = None,
+    *,
     scale: int = 2,
 ) -> EpsImagePlugin.EpsImageFile:
     if barcode_type not in barcode_types:

--- a/src/treepoem/__main__.py
+++ b/src/treepoem/__main__.py
@@ -48,7 +48,7 @@ parser.add_argument(
     "-s",
     "--scale",
     type=check_scale,
-    default="2",
+    default=2,
     help="Factor scaling the output image size (default is 2).",
 )
 parser.add_argument("data", help="Barcode data")
@@ -62,7 +62,7 @@ def main() -> None:
     type_: str = args.type
     format_: str | None = args.format
     output: str | None | BinaryIO = args.output
-    scale: int | None = args.scale
+    scale: int = args.scale
     data: str = args.data
     options: dict[str, str | bool] = dict(args.options)
 
@@ -81,7 +81,7 @@ def main() -> None:
     if output is stdout_binary and format_ is None:
         format_ = "xbm"
 
-    image = generate_barcode(type_, data, options, scale)
+    image = generate_barcode(type_, data, options, scale=scale)
 
     try:
         image.convert("1").save(output, format_)

--- a/src/treepoem/__main__.py
+++ b/src/treepoem/__main__.py
@@ -23,6 +23,14 @@ def parse_opt(x: str) -> tuple[str, str | bool]:
         return (x, True)
 
 
+def check_scale(value: str) -> int:
+    if not value.isnumeric() or int(value) <= 0:
+        raise argparse.ArgumentTypeError(
+            f'Scale should be a positive integer value. Found "{value}" instead.'
+        )
+    return int(value)
+
+
 parser = argparse.ArgumentParser(epilog=supported_barcode_types)
 parser.add_argument(
     "-t", "--type", default="qrcode", help="Barcode type (default %(default)s)"
@@ -36,6 +44,13 @@ parser.add_argument(
     ),
 )
 parser.add_argument("-o", "--output", help="Output file (default is stdout)")
+parser.add_argument(
+    "-s",
+    "--scale",
+    type=check_scale,
+    default="2",
+    help="Factor scaling the output image size (default is 2).",
+)
 parser.add_argument("data", help="Barcode data")
 parser.add_argument(
     "options", nargs="*", type=parse_opt, help="List of BWIPP options (e.g. width=1.5)"
@@ -47,6 +62,7 @@ def main() -> None:
     type_: str = args.type
     format_: str | None = args.format
     output: str | None | BinaryIO = args.output
+    scale: int | None = args.scale
     data: str = args.data
     options: dict[str, str | bool] = dict(args.options)
 
@@ -65,7 +81,7 @@ def main() -> None:
     if output is stdout_binary and format_ is None:
         format_ = "xbm"
 
-    image = generate_barcode(type_, data, options)
+    image = generate_barcode(type_, data, options, scale)
 
     try:
         image.convert("1").save(output, format_)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -95,3 +95,38 @@ def test_unsupported_file_format(tmp_path, monkeypatch, capsys):
     out, err = capsys.readouterr()
     assert out == ""
     assert "Image format 'invalid-image-format' is not supported" in err
+
+
+def test_scale(tmpdir, monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["treepoem", "-o", str(tmpdir.join("test.png")), "--scale", "4", "barcodedata"],
+    )
+    main()
+    assert tmpdir.join("test.png").check(exists=True)
+
+
+def test_unsupported_scale(tmpdir, monkeypatch, capsys):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "treepoem",
+            "-o",
+            str(tmpdir.join("test.png")),
+            "-s",
+            "unsupported-scale",
+            "barcodedata",
+        ],
+    )
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+    assert excinfo.value.code == 2
+    assert tmpdir.join("test.bin").check(exists=False)
+    out, err = capsys.readouterr()
+    assert out == ""
+    assert (
+        'Scale should be a positive integer value. Found "unsupported-scale" instead.'
+        in err
+    )

--- a/tests/test_treepoem.py
+++ b/tests/test_treepoem.py
@@ -45,6 +45,13 @@ def test_barcode(barcode_type, barcode_data):
     actual.close()
 
 
+def test_scale_0():
+    with pytest.raises(ValueError) as excinfo:
+        treepoem.generate_barcode("code39", "hello", scale=0)
+
+    assert str(excinfo.value) == "scale must be at least 1"
+
+
 @pytest.mark.parametrize(
     "barcode_type,barcode_data",
     [

--- a/tests/test_treepoem.py
+++ b/tests/test_treepoem.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import sys
 from os import path
 
@@ -42,6 +43,25 @@ def test_barcode(barcode_type, barcode_data):
         assert bbox is None
 
     actual.close()
+
+
+@pytest.mark.parametrize(
+    "barcode_type,barcode_data",
+    [
+        ("qrcode", "This is qrcode barcode."),
+        ("azteccode", "This is azteccode barcode."),
+        ("azteccode", b"This is azteccode barcode."),
+        ("pdf417", "This is pdf417 barcode."),
+        ("interleaved2of5", "0123456789"),
+        ("code128", "This is code128 barcode."),
+        ("code39", "THIS IS CODE39 BARCODE."),
+    ],
+)
+def test_scale(barcode_type, barcode_data):
+    actual = treepoem.generate_barcode(barcode_type, barcode_data)
+    actual_resized = treepoem.generate_barcode(barcode_type, barcode_data, scale=4)
+    assert math.ceil(actual.size[0] / 2) == math.ceil(actual_resized.size[0] / 4)
+    assert math.ceil(actual.size[1] / 2) == math.ceil(actual_resized.size[1] / 4)
 
 
 @pytest.fixture

--- a/tests/test_treepoem.py
+++ b/tests/test_treepoem.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import math
 import sys
 from os import path
 
@@ -47,28 +46,24 @@ def test_barcode(barcode_type, barcode_data):
 
 def test_scale_0():
     with pytest.raises(ValueError) as excinfo:
-        treepoem.generate_barcode("code39", "hello", scale=0)
+        treepoem.generate_barcode("code39", "HELLO", scale=0)
 
     assert str(excinfo.value) == "scale must be at least 1"
 
 
-@pytest.mark.parametrize(
-    "barcode_type,barcode_data",
-    [
-        ("qrcode", "This is qrcode barcode."),
-        ("azteccode", "This is azteccode barcode."),
-        ("azteccode", b"This is azteccode barcode."),
-        ("pdf417", "This is pdf417 barcode."),
-        ("interleaved2of5", "0123456789"),
-        ("code128", "This is code128 barcode."),
-        ("code39", "THIS IS CODE39 BARCODE."),
-    ],
-)
-def test_scale(barcode_type, barcode_data):
-    actual = treepoem.generate_barcode(barcode_type, barcode_data)
-    actual_resized = treepoem.generate_barcode(barcode_type, barcode_data, scale=4)
-    assert math.ceil(actual.size[0] / 2) == math.ceil(actual_resized.size[0] / 4)
-    assert math.ceil(actual.size[1] / 2) == math.ceil(actual_resized.size[1] / 4)
+def test_scale_1():
+    out = treepoem.generate_barcode("code39", "HELLO", scale=1)
+    assert out.size == (111, 74)
+
+
+def test_scale_2():
+    out = treepoem.generate_barcode("code39", "HELLO")
+    assert out.size == (222, 146)
+
+
+def test_scale_4():
+    out = treepoem.generate_barcode("code39", "HELLO", scale=4)
+    assert out.size == (444, 290)
 
 
 @pytest.fixture


### PR DESCRIPTION
Hi @adamchainz ,
Thank you again for your feedback on https://github.com/adamchainz/treepoem/pull/432. I am opening a new Pull Request based on a feature branch which incorporated your feedback and implements a single argument for scale (`scale: int = 2`) in the signature of the `generate_barcode` function.

In addition, the CLI is amended to support the `scale` parameter, two tests for the CLI have been added and the test for the barcode generation now follows the [arrange act assert](https://jamescooke.info/arrange-act-assert-pattern-for-python-developers.html) pattern. (Thanks for the link!) 

Looking forward to your feedback.

Best
Nico
