### PR TITLE
Improve conftest version retrieval

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,20 @@
 from __future__ import annotations
 
 import subprocess
+from functools import lru_cache
 
 from treepoem import _ghostscript_binary
 
-GHOSTSCRIPT_VERSION = subprocess.check_output(
-    [_ghostscript_binary(), "--version"]
-).decode("utf-8")
+
+@lru_cache(maxsize=None)
+def ghostscript_version() -> str:
+    return subprocess.run(
+        [_ghostscript_binary(), "--version"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
 
 
 def pytest_report_header(config):
-    return f"Ghostscript version: {GHOSTSCRIPT_VERSION}"
+    return f"Ghostscript version: {ghostscript_version()}"


### PR DESCRIPTION
Avoid import-time subprocess call and cache in case the test suite is run multiple times in one process (maybe with some pytest plugin in the future).