### PR TITLE
Use importlib.resources on Python 3.9+

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog
 =========
 
+* Use |importlib.resources|__ on Python 3.9+, which should allow treepoem to work when installed in different packaging scenarios like with zipimport or PyInstaller apps.
+
+  .. |importlib.resources| replace:: ``importlib.resources``
+  __ https://docs.python.org/3/library/importlib.resources.html
+
+  Thanks to HemantShrimali1982 for the initial report in `Issue #273 <https://github.com/adamchainz/treepoem/issues/273>`__.
+
 3.23.0 (2023-08-02)
 -------------------
 

--- a/src/treepoem/__init__.py
+++ b/src/treepoem/__init__.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 from binascii import hexlify
 from functools import lru_cache
+from importlib import resources
 from math import ceil
 from textwrap import TextWrapper
 from textwrap import indent
@@ -24,10 +25,16 @@ __all__ = ["generate_barcode", "TreepoemError", "BarcodeType", "barcode_types"]
 # which disables file operations in the PS code.
 @lru_cache(maxsize=None)
 def load_bwipp() -> str:
-    base_dir = os.path.normpath(os.path.abspath(os.path.dirname(__file__)))
-    bwipp_path = os.path.join(base_dir, "postscriptbarcode", "barcode.ps")
-    with open(bwipp_path) as fp:
-        return fp.read()
+    if sys.version_info >= (3, 9):
+        with resources.files("treepoem").joinpath(
+            "postscriptbarcode/barcode.ps"
+        ).open() as fp:
+            return fp.read()
+    else:
+        base_dir = os.path.normpath(os.path.abspath(os.path.dirname(__file__)))
+        bwipp_path = os.path.join(base_dir, "postscriptbarcode", "barcode.ps")
+        with open(bwipp_path) as fp:
+            return fp.read()
 
 
 # Error handling from:


### PR DESCRIPTION
Fixes #273.

Sticking with the old method on Python 3.8 because the old API there doesn't support files within directories. I’d rather not rearrange the directory structure just to work on an old Python version that we’ll drop support for later this year.